### PR TITLE
- Handling of null response from Avatax API so that checkout actions can proceed.

### DIFF
--- a/app/models/spree/calculator/avalara_transaction_calculator.rb
+++ b/app/models/spree/calculator/avalara_transaction_calculator.rb
@@ -76,6 +76,11 @@ module Spree
       return 0 if item_address.nil?
       return 0 if !self.calculable.zone.include?(item_address)
 
+      if avalara_response['TaxLines'].blank?
+        Rails.logger.error "Avatax response property `TaxLines` null for order #{order.try(:number)} item ID #{item.try(:id)}."
+        return 0
+      end
+
       avalara_response['TaxLines'].each do |line|
         if line['LineNo'] == "#{item.id}-#{item.avatax_line_code}"
           return line['TaxCalculated'].to_f


### PR DESCRIPTION
@kknd113 -- not so urgent since it seemed to happen for only one user so far (graceatbeach@yahoo.com, R383809062)

Here's the stacktrace pulled off new relic which the return here should preempt (https://rpm.newrelic.com/accounts/404364/applications/2431130/traced_errors/fd0360-4b23e576-7844-11e5-8ba7-b82a72d2466d):

```
NoMethodError: undefined method `each' for nil:NilClass
…els/spree/calculator/avalara_transaction_calculator.rb:  79:in `tax_for_item'
…els/spree/calculator/avalara_transaction_calculator.rb:  21:in `compute_shipment_or_line_item'
…spree-37687d678dec/core/app/models/spree/calculator.rb:  14:in `compute'
…s/spree-37687d678dec/core/app/models/spree/tax_rate.rb: 176:in `compute_amount'
…s/spree-37687d678dec/core/app/models/spree/tax_rate.rb: 148:in `adjust'
```

Open to any suggestions since I am unfamiliar with this repo.
