### PR TITLE
Fix multiple RMA issues

### DIFF
--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -24,13 +24,13 @@ module Spree
       post_order_to_avalara(false, order_details.line_items, order_details)
     end
 
-    def commit_avatax(items, order_details, doc_id=nil, org_ord_date=nil, invoice_dt=nil)
-      post_order_to_avalara(false, items, order_details, doc_id, org_ord_date, invoice_dt)
+    def commit_avatax(items, order_details, doc_id=nil, org_ord_date=nil, invoice_dt=nil, rma_id=nil)
+      post_order_to_avalara(false, items, order_details, doc_id, org_ord_date, invoice_dt, rma_id)
     end
 
-    def commit_avatax_final(items, order_details,doc_id=nil, org_ord_date=nil, invoice_dt=nil)
+    def commit_avatax_final(items, order_details,doc_id=nil, org_ord_date=nil, invoice_dt=nil, rma_id=nil)
       if document_committing_enabled?
-        post_order_to_avalara(true, items, order_details, doc_id, org_ord_date,invoice_dt)
+        post_order_to_avalara(true, items, order_details, doc_id, org_ord_date,invoice_dt, rma_id)
       else
         AVALARA_TRANSACTION_LOGGER.debug "avalara document committing disabled"
         "avalara document committing disabled"
@@ -333,7 +333,7 @@ module Spree
       }
     end
 
-    def post_order_to_avalara(commit=false, orderitems=nil, order_details=nil, doc_code=nil, org_ord_date=nil, invoice_detail=nil)
+    def post_order_to_avalara(commit=false, orderitems=nil, order_details=nil, doc_code=nil, org_ord_date=nil, invoice_detail=nil, rma_id=nil)
       AVALARA_TRANSACTION_LOGGER.info("post order to avalara")
       address_validator = AddressSvc.new
       tax_line_items = []
@@ -414,7 +414,7 @@ module Spree
        
 
         order_details.return_authorizations.each do |return_auth|
-          next if return_auth.state == 'received'
+          next if return_auth.state == 'received' || return_auth.id != rma_id
           tax_line_items<<return_authorization_line(return_auth)
           
           if rma_shipping_adj = order_details.adjustments.where(originator_type: "Spree::ShippingMethod").last

--- a/app/models/spree/return_authorization_decorator.rb
+++ b/app/models/spree/return_authorization_decorator.rb
@@ -25,7 +25,7 @@ Spree::ReturnAuthorization.class_eval do
 
     begin
       avalara_lookup
-      @rtn_tax = Spree::AvalaraTransaction.find_by_return_authorization_id(self.id).commit_avatax(order.line_items, order, order.number.to_s + ":" + self.id.to_s, order.completed_at.strftime("%F"), "ReturnInvoice")
+      @rtn_tax = Spree::AvalaraTransaction.find_by_return_authorization_id(self.id).commit_avatax(order.line_items, order, order.number.to_s + ":" + self.id.to_s, order.completed_at.strftime("%F"), "ReturnInvoice", self.id)
 
       RETURN_AUTHORIZATION_LOGGER.info 'tax amount'
       RETURN_AUTHORIZATION_LOGGER.debug @rtn_tax
@@ -40,7 +40,7 @@ Spree::ReturnAuthorization.class_eval do
 
     begin
       avalara_lookup
-      @rtn_tax = self.reload.avalara_transaction.commit_avatax_final(order.line_items, order, order.number.to_s + ":" + self.id.to_s, order.completed_at.strftime("%F"), "ReturnInvoice")
+      @rtn_tax = self.reload.avalara_transaction.commit_avatax_final(order.line_items, order, order.number.to_s + ":" + self.id.to_s, order.completed_at.strftime("%F"), "ReturnInvoice", self.id)
 
       RETURN_AUTHORIZATION_LOGGER.info 'tax amount'
       RETURN_AUTHORIZATION_LOGGER.debug @rtn_tax


### PR DESCRIPTION
@sankalpk 
# Problem

The default RMA behavior of `spree_avatax_certified` gem is that it iterates through _all_ the RMAs associated with the order. This does not work so well with our current spree RMA behavior since we often create multiple RMAs but only want to receive some of them.
# Solution

For now, I'm passing in `return_authorization.id` to make sure we only commit desired RMA to Avatax. Ideally, I would want to do large refactor the code to be more suitable for our spree usage, but I'm going with this fix for now. This is because this bug is considered semi-urgent due to approaching holiday season and we have Spree upgrade + Solidus integration on our roadmap.
